### PR TITLE
Cross-build for 2.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: scala
 scala:
   - 2.10.5
+  - 2.11.6
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk6
 
-script: sbt ++$TRAVIS_SCALA_VERSION +test
+script: sbt ++$TRAVIS_SCALA_VERSION test

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -11,13 +11,13 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.slf4j"       % "slf4j-api"                 % "1.7.+",
-  "ch.qos.logback"  % "logback-classic"           % "1.0.+",
+  "org.slf4j"       % "slf4j-api"                 % "1.7.12",
+  "ch.qos.logback"  % "logback-classic"           % "1.1.3",
   "org.scalaz"     %% "scalaz-core"               % "7.1.2",
   "org.scalaz"     %% "scalaz-concurrent"         % "7.1.2",
-  "org.scala-lang"  % "scala-reflect"             % "2.10.5" % "provided",
+  "org.scala-lang"  % "scala-reflect"             % scalaVersion.value % "provided",
   "org.scalaz"     %% "scalaz-scalacheck-binding" % "7.1.2"  % "test",
-  "org.scalacheck" %% "scalacheck"                % "1.10.1" % "test"
+  "org.scalacheck" %% "scalacheck"                % "1.12.3" % "test"
 )
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/project.sbt
+++ b/project.sbt
@@ -3,6 +3,8 @@ organization in Global := "oncue.journal"
 
 scalaVersion in Global := "2.10.5"
 
+crossScalaVersions in Global := Seq("2.10.5", "2.11.6")
+
 resolvers += Resolver.sonatypeRepo("releases")
 
 lazy val journal = project.in(file(".")).aggregate(core).settings(publish := {})

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,11 +10,8 @@ resolvers += Resolver.url(
         Resolver.ivyStylePatterns)
 
 addSbtPlugin("me.lessis"         % "bintray-sbt" % "0.3.0")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"    % "0.8.1")
-
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages" % "0.5.3")
-
-addSbtPlugin("org.tpolecat"      % "tut-plugin"  % "0.3.1")
+addSbtPlugin("org.tpolecat"      % "tut-plugin"  % "0.3.2")
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates" % "0.1.8")


### PR DESCRIPTION
Dependency syntax like 1.0.+ is bad practice as only ivy
understands it (and even that is a stretch.)
