### PR TITLE
Make LogMessage constructors final

### DIFF
--- a/core/src/main/scala/journal/LogMessage.scala
+++ b/core/src/main/scala/journal/LogMessage.scala
@@ -18,7 +18,7 @@
 package journal
 
 sealed trait LogMessage
-case class Error(message: String, cause: Option[Throwable] = None) extends LogMessage
-case class Info(message: String, cause: Option[Throwable] = None) extends LogMessage
-case class Warn(message: String, cause: Option[Throwable] = None) extends LogMessage
-case class Debug(message: String, cause: Option[Throwable] = None) extends LogMessage
+final case class Error(message: String, cause: Option[Throwable] = None) extends LogMessage
+final case class Info(message: String, cause: Option[Throwable] = None) extends LogMessage
+final case class Warn(message: String, cause: Option[Throwable] = None) extends LogMessage
+final case class Debug(message: String, cause: Option[Throwable] = None) extends LogMessage


### PR DESCRIPTION
I don't believe these are intended to be extended (and case classes
generally shouldn't be).
