### PR TITLE
Upgrade scalaz

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,11 +1,12 @@
+val scalazVersion = "7.2.8"
 
 libraryDependencies ++= Seq(
   "org.slf4j"       % "slf4j-api"                 % "1.7.12",
   "ch.qos.logback"  % "logback-classic"           % "1.1.3",
-  "org.scalaz"     %% "scalaz-core"               % "7.1.2",
-  "org.scalaz"     %% "scalaz-concurrent"         % "7.1.2",
+  "org.scalaz"     %% "scalaz-core"               % scalazVersion,
+  "org.scalaz"     %% "scalaz-concurrent"         % scalazVersion,
   "org.scala-lang"  % "scala-reflect"             % scalaVersion.value % "provided",
-  "org.scalaz"     %% "scalaz-scalacheck-binding" % "7.1.2"  % "test",
+  "org.scalaz"     %% "scalaz-scalacheck-binding" % scalazVersion % "test",
   "org.scalacheck" %% "scalacheck"                % "1.12.3" % "test"
 )
 

--- a/core/src/main/scala-2.10/journal/ContextType.scala
+++ b/core/src/main/scala-2.10/journal/ContextType.scala
@@ -1,0 +1,7 @@
+package journal
+
+import scala.reflect.macros.Context
+
+object ContextType {
+  type ContextType = Context
+}

--- a/core/src/main/scala-2.11/journal/ContextType.scala
+++ b/core/src/main/scala-2.11/journal/ContextType.scala
@@ -1,0 +1,7 @@
+package journal
+
+import scala.reflect.macros.whitebox
+
+object ContextType {
+  type ContextType = whitebox.Context
+}

--- a/core/src/main/scala/journal/Logger.scala
+++ b/core/src/main/scala/journal/Logger.scala
@@ -19,7 +19,6 @@ package journal
 
 import org.slf4j.{Logger => Backend, LoggerFactory}
 import scalaz.concurrent._
-import scala.reflect.macros.Context
 import java.util.concurrent.{ThreadFactory, Executors}
 
 sealed class Logger(val backend: Backend, val handler: Actor[LogMessage]) {
@@ -51,7 +50,7 @@ sealed class Logger(val backend: Backend, val handler: Actor[LogMessage]) {
  * Thanks to Heiko Seeberger et al for creating Scala Logging.
  */
 private object LoggerMacro {
-  type LoggerContext = Context { type PrefixType = Logger }
+  type LoggerContext = ContextType.ContextType { type PrefixType = Logger }
 
   def errorMessage(c: LoggerContext)(message: c.Expr[String]) =
     c.universe.reify {

--- a/core/src/test/scala/LoggerTests.scala
+++ b/core/src/test/scala/LoggerTests.scala
@@ -18,13 +18,15 @@
 package journal
 
 import org.slf4j.helpers.NOPLogger
+import org.slf4j.{Marker, Logger => Backend}
 import org.scalacheck.Properties
 
 object LoggerTests extends Properties("Logger") {
-  private[this] val log: Logger = Logger(NOPLogger.NOP_LOGGER)
   private[this] val up: Throwable = new RuntimeException("blargh")
 
   property("doesn't eagerly evaluate") = {
+    val log: Logger = Logger(NOPLogger.NOP_LOGGER)
+
     var evaluated: Boolean = false
     def evaluateMessage(): String = {
       evaluated = true
@@ -46,4 +48,92 @@ object LoggerTests extends Properties("Logger") {
     !evaluated
   }
 
+  property("does evaluate when required") = {
+    object SilentLogger extends Backend {
+      //  So...many...methods...
+      override def warn(msg: String): Unit = ()
+      override def warn(format: String, arg: scala.Any): Unit = ()
+      override def warn(format: String, arguments: AnyRef*): Unit = ()
+      override def warn(format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def warn(msg: String, t: Throwable): Unit = ()
+      override def warn(marker: Marker, msg: String): Unit = ()
+      override def warn(marker: Marker, format: String, arg: scala.Any): Unit = ()
+      override def warn(marker: Marker, format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def warn(marker: Marker, format: String, arguments: AnyRef*): Unit = ()
+      override def warn(marker: Marker, msg: String, t: Throwable): Unit = ()
+      override def isErrorEnabled: Boolean = true
+      override def isErrorEnabled(marker: Marker): Boolean = true
+      override def getName: String = "test"
+      override def isInfoEnabled: Boolean = true
+      override def isInfoEnabled(marker: Marker): Boolean = true
+      override def isDebugEnabled: Boolean = true
+      override def isDebugEnabled(marker: Marker): Boolean = ???
+      override def isTraceEnabled: Boolean = true
+      override def isTraceEnabled(marker: Marker): Boolean = true
+      override def error(msg: String): Unit = ()
+      override def error(format: String, arg: scala.Any): Unit = ()
+      override def error(format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def error(format: String, arguments: AnyRef*): Unit = ()
+      override def error(msg: String, t: Throwable): Unit = ()
+      override def error(marker: Marker, msg: String): Unit = ()
+      override def error(marker: Marker, format: String, arg: scala.Any): Unit = ()
+      override def error(marker: Marker, format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def error(marker: Marker, format: String, arguments: AnyRef*): Unit = ()
+      override def error(marker: Marker, msg: String, t: Throwable): Unit = ()
+      override def debug(msg: String): Unit = ()
+      override def debug(format: String, arg: scala.Any): Unit = ()
+      override def debug(format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def debug(format: String, arguments: AnyRef*): Unit = ()
+      override def debug(msg: String, t: Throwable): Unit = ()
+      override def debug(marker: Marker, msg: String): Unit = ()
+      override def debug(marker: Marker, format: String, arg: scala.Any): Unit = ()
+      override def debug(marker: Marker, format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def debug(marker: Marker, format: String, arguments: AnyRef*): Unit = ()
+      override def debug(marker: Marker, msg: String, t: Throwable): Unit = ()
+      override def isWarnEnabled: Boolean = true
+      override def isWarnEnabled(marker: Marker): Boolean = true
+      override def trace(msg: String): Unit = ()
+      override def trace(format: String, arg: scala.Any): Unit = ()
+      override def trace(format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def trace(format: String, arguments: AnyRef*): Unit = ()
+      override def trace(msg: String, t: Throwable): Unit = ()
+      override def trace(marker: Marker, msg: String): Unit = ()
+      override def trace(marker: Marker, format: String, arg: scala.Any): Unit = ()
+      override def trace(marker: Marker, format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def trace(marker: Marker, format: String, argArray: AnyRef*): Unit = ()
+      override def trace(marker: Marker, msg: String, t: Throwable): Unit = ()
+      override def info(msg: String): Unit = ()
+      override def info(format: String, arg: scala.Any): Unit = ()
+      override def info(format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def info(format: String, arguments: AnyRef*): Unit = ()
+      override def info(msg: String, t: Throwable): Unit = ()
+      override def info(marker: Marker, msg: String): Unit = ()
+      override def info(marker: Marker, format: String, arg: scala.Any): Unit = ()
+      override def info(marker: Marker, format: String, arg1: scala.Any, arg2: scala.Any): Unit = ()
+      override def info(marker: Marker, format: String, arguments: AnyRef*): Unit = ()
+      override def info(marker: Marker, msg: String, t: Throwable): Unit = ()
+    }
+
+    val log: Logger = Logger(SilentLogger)
+
+    var evaluationCount: Int = 0
+    def evaluateMessage(): String = {
+      evaluationCount += 1
+      "a crazy side-effecting string"
+    }
+
+    // without cause
+    log.debug(evaluateMessage())
+    log.info(evaluateMessage())
+    log.warn(evaluateMessage())
+    log.error(evaluateMessage())
+
+    // with cause
+    log.debug(evaluateMessage(), up)
+    log.info(evaluateMessage(), up)
+    log.warn(evaluateMessage(), up)
+    log.error(evaluateMessage(), up)
+
+    evaluationCount == 8
+  }
 }


### PR DESCRIPTION
As discussed in https://functionalprogramming.slack.com/messages/scala/ here's a pull request containing the upgrade to scalaz 7.2.8 (which is literally just a recompile, so no real substance there).

I also (separate commit) cleaned up the deprecation warning relating to the forthcoming changes to macros, and added an extra test case for my own sanity in verification.

I'm not sure how you want to/plan to handle support of multiple different versions, so this may only make sense as a branch, but anyway, please do as you see fit with it.