### PR TITLE
Upgrade Logback to latest version

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,7 +1,7 @@
 
 libraryDependencies ++= Seq(
   "org.slf4j"       % "slf4j-api"                 % "1.7.12",
-  "ch.qos.logback"  % "logback-classic"           % "1.1.3",
+  "ch.qos.logback"  % "logback-classic"           % "1.2.3",
   "org.scala-lang"  % "scala-reflect"             % scalaVersion.value % "provided"
 )
 


### PR DESCRIPTION
Logback 1.1.3 has known security vulnerability (see https://logback.qos.ch/news.html) which whilst Journal is not exposed to, does cause the transitive dependency to be flagged up by tools such as whitesource.